### PR TITLE
Include exception identifier in try/catch blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,13 +57,13 @@ function parse(str, filename) {
     if (/^\s*{/.test(str)) {
         try {
             _parse('edn');
-        } catch {
+        } catch (e) {
             _parse('json');
         }
     } else {
         try {
             _parse('yaml');
-        } catch {
+        } catch (e) {
             _parse('ini');
         }
     }
@@ -80,7 +80,7 @@ async function loadFileConfig({ name, paths, loaders }) {
             files.push(
                 loaders.reduce(async (acc, loader) => await loader(acc, filename),
                 parse(await readFile(filename, { encoding: 'utf8' }), filename)));
-        } catch {}
+        } catch (e) {}
     }
     return merge(...(await Promise.all(files)));
 }


### PR DESCRIPTION
Ran into a problem with an older version of Node.js (8.7.0). It didn't like that there was no exception identifier provided.